### PR TITLE
CRISTIANARCIAO56

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Canoe works by reading a contract's ABI and decoding the constructor bytecode wi
 
 ## Install
 
-    npm install canoe-soldity
+    npm install canoe-solidity
 
 ## Requirements
 - ABI schema 2.0

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Canoe works by reading a contract's ABI and decoding the constructor bytecode wi
 <dt><a href="#encodeConstructorArgs">encodeConstructorArgs(inputs)</a> ⇒ <code>string</code></dt>
 <dd><p>Generates constructor args bytecode based on input data.</p>
 </dd>
+<dt><a href="#decodeFunctionArgs">decodeFunctionArgs(contractABI, bytecode)</a> ⇒ <code>Object</code></dt>
+<dd><p>Decodes function call args.</p>
+</dd>
 </dl>
 
 <a name="decodeConstructorArgs"></a>
@@ -49,6 +52,20 @@ Generates constructor args bytecode based on input data.
 | inputs | <code>Array.&lt;Object&gt;</code> | Array of objects with name, and type fields |
 | inputs[].name | <code>string</code> | Name of argument |
 | inputs[].type | <code>string</code> | Type of argument |
+
+
+<a name="decodeFunctionArgs"></a>
+
+### decodeFunctionArgs(contractABI, bytecode) ⇒ <code>Object</code>
+Decodes function args.
+
+**Kind**: global function  
+**Returns**: <code>Object</code> - decodedArgs - Object representing decoded args with name, type, and data fields  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| contractABI | <code>Object</code> | ABI of contract whose args to decode |
+| bytecode | <code>string</code> | function args bytecode, methohID included |
 
 
 ### Supported Types
@@ -98,7 +115,7 @@ Generates constructor args bytecode based on input data.
           'stateMutability': 'nonpayable',
           'type': 'constructor'
         }
-      ];
+      ]
     };
     let bytecodeExample = '00000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000008ac7230489e80000000000000000000000000000000000000000000000000000000000000000016000000000000000000000000000000000000000000000000000000000000001a00000000000000000000000000000000000000000000000000000000000000002000000000000000000000000ffffffffffffffffffffffffffffffffffffffff000000000000000000000000f1e48f13768bd8114a530070b43257a63f24bb1200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000005000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000012457468657265756d31302051322d32303138000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034531300000000000000000000000000000000000000000000000000000000000';
     decodeConstructorArgs(abiExample.abi, bytecodeExample);

--- a/index.js
+++ b/index.js
@@ -77,11 +77,11 @@ function decodeFunctionArgs(contractABI, bytecode) {
   const func = _.find(contractABI,  function(o) {
     if (o.type === 'function') {
       const inputTypes = _.pluck(o.inputs, 'type');
-      return methodID.compare(abi.methodID(o.name, inputTypes)) === 0;
+      return methodID.equals(abi.methodID(o.name, inputTypes));
     }
     return false;
   });
-  
+
   if (!func) {
     return null;
   }

--- a/scripts/endecodeHelper.js
+++ b/scripts/endecodeHelper.js
@@ -26,7 +26,7 @@ let inputs = [
     'name': 'strings',
     'type': 'string[]',
     'data': ['0xaa', '0xbb', '0xcc', '0xdd']
-  }
+  },
   {
     'name': 'bytes',
     'type': 'bytes',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,6 @@
 const chai = require('chai');
 const assert = chai.assert;
-const { encodeConstructorArgs, decodeConstructorArgs } = require('../index.js');
+const { encodeConstructorArgs, decodeConstructorArgs, decodeFunctionArgs } = require('../index.js');
 
 
 describe('single values', function() {
@@ -424,3 +424,459 @@ describe('real world contracts', function() {
   });
 
 });
+
+describe('decode function', function() {
+
+  it('should correctly decode erc20 transfer', function() {
+    const contractABI = {
+      'abi': [
+        {
+          "constant": true,
+          "inputs": [
+
+          ],
+          "name": "name",
+          "outputs": [
+            {
+              "name": "",
+              "type": "string"
+            }
+          ],
+          "payable": false,
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "constant": false,
+          "inputs": [
+            {
+              "name": "spender",
+              "type": "address"
+            },
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "approve",
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ],
+          "payable": false,
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "constant": true,
+          "inputs": [
+
+          ],
+          "name": "totalSupply",
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "payable": false,
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "constant": false,
+          "inputs": [
+            {
+              "name": "from",
+              "type": "address"
+            },
+            {
+              "name": "to",
+              "type": "address"
+            },
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "transferFrom",
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ],
+          "payable": false,
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "constant": true,
+          "inputs": [
+
+          ],
+          "name": "decimals",
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "payable": false,
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "constant": false,
+          "inputs": [
+            {
+              "name": "spender",
+              "type": "address"
+            },
+            {
+              "name": "addedValue",
+              "type": "uint256"
+            }
+          ],
+          "name": "increaseAllowance",
+          "outputs": [
+            {
+              "name": "success",
+              "type": "bool"
+            }
+          ],
+          "payable": false,
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "constant": false,
+          "inputs": [
+
+          ],
+          "name": "unpause",
+          "outputs": [
+
+          ],
+          "payable": false,
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "constant": false,
+          "inputs": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "burn",
+          "outputs": [
+
+          ],
+          "payable": false,
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "constant": true,
+          "inputs": [
+
+          ],
+          "name": "paused",
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ],
+          "payable": false,
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "constant": true,
+          "inputs": [
+            {
+              "name": "owner",
+              "type": "address"
+            }
+          ],
+          "name": "balanceOf",
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "payable": false,
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "constant": false,
+          "inputs": [
+
+          ],
+          "name": "pause",
+          "outputs": [
+
+          ],
+          "payable": false,
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "constant": true,
+          "inputs": [
+
+          ],
+          "name": "owner",
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            }
+          ],
+          "payable": false,
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "constant": true,
+          "inputs": [
+
+          ],
+          "name": "isOwner",
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ],
+          "payable": false,
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "constant": true,
+          "inputs": [
+
+          ],
+          "name": "symbol",
+          "outputs": [
+            {
+              "name": "",
+              "type": "string"
+            }
+          ],
+          "payable": false,
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "constant": false,
+          "inputs": [
+            {
+              "name": "spender",
+              "type": "address"
+            },
+            {
+              "name": "subtractedValue",
+              "type": "uint256"
+            }
+          ],
+          "name": "decreaseAllowance",
+          "outputs": [
+            {
+              "name": "success",
+              "type": "bool"
+            }
+          ],
+          "payable": false,
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "constant": false,
+          "inputs": [
+            {
+              "name": "to",
+              "type": "address"
+            },
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "transfer",
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ],
+          "payable": false,
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "constant": true,
+          "inputs": [
+            {
+              "name": "owner",
+              "type": "address"
+            },
+            {
+              "name": "spender",
+              "type": "address"
+            }
+          ],
+          "name": "allowance",
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "payable": false,
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "constant": false,
+          "inputs": [
+            {
+              "name": "newOwner",
+              "type": "address"
+            }
+          ],
+          "name": "transferOwnership",
+          "outputs": [
+
+          ],
+          "payable": false,
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "name": "initialSupply",
+              "type": "uint256"
+            },
+            {
+              "name": "tokenName",
+              "type": "string"
+            },
+            {
+              "name": "decimalUnits",
+              "type": "uint256"
+            },
+            {
+              "name": "tokenSymbol",
+              "type": "string"
+            }
+          ],
+          "payable": false,
+          "stateMutability": "nonpayable",
+          "type": "constructor"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+
+          ],
+          "name": "Paused",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+
+          ],
+          "name": "Unpaused",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "name": "previousOwner",
+              "type": "address"
+            },
+            {
+              "indexed": true,
+              "name": "newOwner",
+              "type": "address"
+            }
+          ],
+          "name": "OwnershipTransferred",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "name": "from",
+              "type": "address"
+            },
+            {
+              "indexed": true,
+              "name": "to",
+              "type": "address"
+            },
+            {
+              "indexed": false,
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "Transfer",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "name": "owner",
+              "type": "address"
+            },
+            {
+              "indexed": true,
+              "name": "spender",
+              "type": "address"
+            },
+            {
+              "indexed": false,
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "Approval",
+          "type": "event"
+        }
+      ]
+    };
+    const argsData = 'a9059cbb000000000000000000000000b5dc69f37dc69f559b6931defefca2e67ab7645500000000000000000000000000000000000000000000152d02c7e14af6800000';
+    const result = decodeFunctionArgs(contractABI.abi, argsData);
+    const expected = [
+      {
+        'name': 'to',
+        'type': 'address',
+        'data': 'b5dc69f37dc69f559b6931defefca2e67ab76455'
+      },
+      {
+        'name': 'value',
+        'type': 'uint256',
+        'data': '100000000000000000000000'
+      }
+    ];
+    assert.deepEqual(result, expected, 'result should match expected');
+  });  
+})


### PR DESCRIPTION
Skip to content
 ensdomains / ens
Code Issues 43 Pull requests 7 Projects 0 Wiki Security Pulse Community
ens/contracts/ENS.lll
@yuanfeiz yuanfeiz Adjust project directory to conform with truffle setup (#106)
5c2167b on 5 Apr 2017
293 lines (218 sloc)  9.99 KB
 
;;; ---------------------------------------------------------------------------
;;; @title The Ethereum Name Service registry.
;;; @author Daniel Ellison <daniel@syrinx.net>

(seq

  ;; --------------------------------------------------------------------------
  ;; Constant definitions.

  ;; Memory layout.
  (def 'node-bytes  0x00)
  (def 'label-bytes 0x20)
  (def 'call-result 0x40)

  ;; Struct: Record
  (def 'resolver 0x00) ; address
  (def 'owner    0x20) ; address
  (def 'ttl      0x40) ; uint64

  ;; Precomputed function IDs.
  (def 'get-node-owner    0x02571be3) ; owner(bytes32)
  (def 'get-node-resolver 0x0178b8bf) ; resolver(bytes32)
  (def 'get-node-ttl      0x16a25cbd) ; ttl(bytes32)
  (def 'set-node-owner    0x5b0fc9c3) ; setOwner(bytes32,address)
  (def 'set-subnode-owner 0x06ab5923) ; setSubnodeOwner(bytes32,bytes32,address)
  (def 'set-node-resolver 0x1896f70a) ; setResolver(bytes32,address)
  (def 'set-node-ttl      0x14ab9038) ; setTTL(bytes32,uint64)

  ;; Jumping here causes an EVM error.
  (def 'invalid-location 0x02)

  ;; --------------------------------------------------------------------------
  ;; @notice Shifts the leftmost 4 bytes of a 32-byte number right by 28 bytes.
  ;; @param input A 32-byte number.

  (def 'shift-right (input)
    (div input (exp 2 224)))

  ;; --------------------------------------------------------------------------
  ;; @notice Determines whether the supplied function ID matches a known
  ;;         function hash and executes <code-body> if so.
  ;; @dev The function ID is in the leftmost four bytes of the call data.
  ;; @param function-hash The four-byte hash of a known function signature.
  ;; @param code-body The code to run in the case of a match.

  (def 'function (function-hash code-body)
    (when (= (shift-right (calldataload 0x00)) function-hash)
      code-body))

  ;; --------------------------------------------------------------------------
  ;; @notice Calculates record location for the node and label passed in.
  ;; @param node The parent node.
  ;; @param label The hash of the subnode label.

  (def 'get-record (node label)
    (seq
      (mstore node-bytes node)
      (mstore label-bytes label)
      (sha3 node-bytes 64)))

  ;; --------------------------------------------------------------------------
  ;; @notice Retrieves owner from node record.
  ;; @param node Get owner of this node.

  (def 'get-owner (node)
    (sload (+ node owner)))

  ;; --------------------------------------------------------------------------
  ;; @notice Stores new owner in node record.
  ;; @param node Set owner of this node.
  ;; @param new-owner New owner of this node.

  (def 'set-owner (node new-owner)
    (sstore (+ node owner) new-owner))

  ;; --------------------------------------------------------------------------
  ;; @notice Stores new subnode owner in node record.
  ;; @param node Set owner of this node.
  ;; @param label The hash of the label specifying the subnode.
  ;; @param new-owner New owner of the subnode.

  (def 'set-subowner (node label new-owner)
    (sstore (+ (get-record node label) owner) new-owner))

  ;; --------------------------------------------------------------------------
  ;; @notice Retrieves resolver from node record.
  ;; @param node Get resolver of this node.

  (def 'get-resolver (node)
    (sload node))

  ;; --------------------------------------------------------------------------
  ;; @notice Stores new resolver in node record.
  ;; @param node Set resolver of this node.
  ;; @param new-resolver New resolver for this node.

  (def 'set-resolver (node new-resolver)
    (sstore node new-resolver))

  ;; --------------------------------------------------------------------------
  ;; @notice Retrieves TTL From node record.
  ;; @param node Get TTL of this node.

  (def 'get-ttl (node)
    (sload (+ node ttl)))

  ;; --------------------------------------------------------------------------
  ;; @notice Stores new TTL in node record.
  ;; @param node Set TTL of this node.
  ;; @param new-resolver New TTL for this node.

  (def 'set-ttl (node new-ttl)
    (sstore (+ node ttl) new-ttl))

  ;; --------------------------------------------------------------------------
  ;; @notice Checks that the caller is the node owner.
  ;; @param node Check owner of this node.

  (def 'only-node-owner (node)
    (when (!= (caller) (get-owner node))
      (jump invalid-location)))

  ;; --------------------------------------------------------------------------
  ;; INIT

  ;; Set the owner of the root node (0x00) to the deploying account.
  (set-owner 0x00 (caller))

  ;; --------------------------------------------------------------------------
  ;; CODE

  (returnlll
    (seq

      ;; ----------------------------------------------------------------------
      ;; @notice Returns the address of the resolver for the specified node.
      ;; @dev Signature: resolver(bytes32)
      ;; @param node Return this node's resolver.
      ;; @return The associated resolver.

      (def 'node (calldataload 0x04))

      (function get-node-resolver
        (seq

          ;; Get the node's resolver and save it.
          (mstore call-result (get-resolver node))

          ;; Return result.
          (return call-result 32)))

      ;; ----------------------------------------------------------------------
      ;; @notice Returns the address that owns the specified node.
      ;; @dev Signature: owner(bytes32)
      ;; @param node Return this node's owner.
      ;; @return The associated address.

      (def 'node (calldataload 0x04))

      (function get-node-owner
        (seq

          ;; Get the node's owner and save it.
          (mstore call-result (get-owner node))

          ;; Return result.
          (return call-result 32)))

      ;; ----------------------------------------------------------------------
      ;; @notice Returns the TTL of a node and any records associated with it.
      ;; @dev Signature: ttl(bytes32)
      ;; @param node Return this node's TTL.
      ;; @return The node's TTL.

      (def 'node (calldataload 0x04))

      (function get-node-ttl
        (seq

          ;; Get the node's TTL and save it.
          (mstore call-result (get-ttl node))

          ;; Return result.
          (return call-result 32)))

      ;; ----------------------------------------------------------------------
      ;; @notice Transfers ownership of a node to a new address. May only be
      ;;         called by the current owner of the node.
      ;; @dev Signature: setOwner(bytes32,address)
      ;; @param node The node to transfer ownership of.
      ;; @param new-owner The address of the new owner.

      (def 'node (calldataload 0x04))
      (def 'new-owner (calldataload 0x24))

      (function set-node-owner
        (seq (only-node-owner node)

          ;; Transfer ownership by storing passed-in address.
          (set-owner node new-owner)

          ;; Emit an event about the transfer.
          ;; Transfer(bytes32 indexed node, address owner);
          (mstore call-result new-owner)
          (log2 call-result 32
              (sha3 0x00 (lit 0x00 "Transfer(bytes32,address)")) node)

          ;; Nothing to return.
          (stop)))

      ;; ----------------------------------------------------------------------
      ;; @notice Transfers ownership of a subnode to a new address. May only be
      ;;         called by the owner of the parent node.
      ;; @dev Signature: setSubnodeOwner(bytes32,bytes32,address)
      ;; @param node The parent node.
      ;; @param label The hash of the label specifying the subnode.
      ;; @param new-owner The address of the new owner.

      (def 'node (calldataload 0x04))
      (def 'label (calldataload 0x24))
      (def 'new-owner (calldataload 0x44))

      (function set-subnode-owner
        (seq (only-node-owner node)

          ;; Transfer ownership by storing passed-in address.
          (set-subowner node label new-owner)

          ;; Emit an event about the transfer.
          ;; NewOwner(bytes32 indexed node, bytes32 indexed label, address owner);
          (mstore call-result new-owner)
          (log3 call-result 32
              (sha3 0x00 (lit 0x00 "NewOwner(bytes32,bytes32,address)"))
              node label)

          ;; Nothing to return.
          (stop)))

      ;; ----------------------------------------------------------------------
      ;; @notice Sets the resolver address for the specified node.
      ;; @dev Signature: setResolver(bytes32,address)
      ;; @param node The node to update.
      ;; @param new-resolver The address of the resolver.

      (def 'node (calldataload 0x04))
      (def 'new-resolver (calldataload 0x24))

      (function set-node-resolver
        (seq (only-node-owner node)

          ;; Transfer ownership by storing passed-in address.
          (set-resolver node new-resolver)

          ;; Emit an event about the change of resolver.
          ;; NewResolver(bytes32 indexed node, address resolver);
          (mstore call-result new-resolver)
          (log2 call-result 32
              (sha3 0x00 (lit 0x00 "NewResolver(bytes32,address)")) node)

          ;; Nothing to return.
          (stop)))

      ;; ----------------------------------------------------------------------
      ;; @notice Sets the TTL for the specified node.
      ;; @dev Signature: setTTL(bytes32,uint64)
      ;; @param node The node to update.
      ;; @param ttl The TTL in seconds.

      (def 'node (calldataload 0x04))
      (def 'new-ttl (calldataload 0x24))

      (function set-node-ttl
        (seq (only-node-owner node)

          ;; Set new TTL by storing passed-in time.
          (set-ttl node new-ttl)

          ;; Emit an event about the change of TTL.
          ;; NewTTL(bytes32 indexed node, uint64 ttl);
          (mstore call-result new-ttl)
          (log2 call-result 32
              (sha3 0x00 (lit 0x00 "NewTTL(bytes32,uint64)")) node)

          ;; Nothing to return.
          (stop)))

      ;; ----------------------------------------------------------------------
      ;; @notice Fallback: No functions matched the function ID provided.

      (jump invalid-location)))

)
© 2019 GitHub, Inc.
Terms
Privacy
Security
Status
Help
Contact GitHub
Pricing
API
Training
Blog
About
